### PR TITLE
Improve stepwise push, add better docs

### DIFF
--- a/scripts/gitPushStepwise.sh
+++ b/scripts/gitPushStepwise.sh
@@ -4,10 +4,18 @@
 # Implement the stepwise push outlined in:
 #   https://docs.github.com/en/get-started/using-git/troubleshooting-the-2-gb-push-limit
 #
-# Requires that the bare git repo that
+# Requires a git repo checked out to the branch you want to push. Usually you should start
+# with the default branch. Once that is pushed, it should be easy to check out other branches
+# you want to keep and push those, with or without the stepwise push script. Then you can push
+# the tags and you will have a complete copy of the git repository.
+#
+# This approach may not work well on some repositories, if it fails you could instead try the
+# chunked-push.sh script outlined in this gist:
+#
+#   https://gist.github.com/robandpdx/86831d48ab7312f844a9e4ec2348b30a#file-chunked-push-sh
 #
 # Usage:
-#    scripts/gitPushStepwise.sh
+#    scripts/gitPushStepwise.sh [branch_name] [remote_name] [step_size]
 
 # Set bash unofficial strict mode http://redsymbol.net/articles/unofficial-bash-strict-mode/
 set -euo pipefail
@@ -37,11 +45,11 @@ STEP_SIZE=${3:-1000}
 export BRANCH_NAME
 
 step_commits=$(git log --oneline --reverse "refs/heads/$BRANCH_NAME" | awk "NR % $STEP_SIZE == 0")
-log INFO "step commits: $step_commits"
+log DEBUG "step commits: $step_commits"
 #shellcheck disable=SC2162,SC2141
 echo "$step_commits" | while IFS=" \n\t" read commit message; do
 	log INFO "commit: $commit"
 	log INFO "message: $message"
 	log INFO "Pushing $commit to $BRANCH_NAME"
-	git push "$REMOTE_NAME" "$commit:refs/heads/$BRANCH_NAME"
+	git push --force --no-follow-tags "$REMOTE_NAME" "$commit:refs/heads/$BRANCH_NAME"
 done


### PR DESCRIPTION
Include link to a more sophisticated approach that may work better
in some cases in the comments.

Using --no-follow-tags helps get past some push failures.

Using --force allows this to be restarted from the beginning on failure.


